### PR TITLE
Change config file extension from `yaml` to `yml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-config.yaml
+app/config.yml
 *.gem
 *.rbc
 /.config
@@ -33,5 +33,4 @@ build/
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
 
-config.yaml
 .idea

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## unreleased (master)
 * Reverse sort articles list, better for pocket order
+* Change config file from `app/config.yaml` to `app/config.yml`
 
 ## 0.2
 * Add warning if not logged-in

--- a/app/server.rb
+++ b/app/server.rb
@@ -3,7 +3,7 @@ require 'sinatra/config_file'
 require 'haml'
 require 'json'
 require 'pocket-ruby'
-config_file 'config.yaml'
+config_file 'config.yml'
 
 enable :sessions
 


### PR DESCRIPTION
Latest sinatra force to use `yml` and fail without