### PR TITLE
Do not output to file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ COPY . /root/pocket-sinatra-interface
 WORKDIR /root/pocket-sinatra-interface
 RUN bundle install
 EXPOSE 80
-CMD ruby app/server.rb -p 80 -o 0.0.0.0 > server.log
+CMD ruby app/server.rb -p 80 -o 0.0.0.0


### PR DESCRIPTION
Allow `docker logs` command to be used