### PR TITLE
Use release instead of master of FileSaver.js

### DIFF
--- a/app/assets/feedly_export_saved_for_later.js
+++ b/app/assets/feedly_export_saved_for_later.js
@@ -34,7 +34,7 @@ function loadJQuery() {
 
 function loadSaveAs() {
     saveAsScript = document.createElement('script');
-    saveAsScript.setAttribute('src', 'https://rawgit.com/eligrey/FileSaver.js/master/FileSaver.js');
+    saveAsScript.setAttribute('src', 'https://rawgit.com/eligrey/FileSaver.js/1.3.4/FileSaver.js');
     saveAsScript.setAttribute('type', 'text/javascript');
     saveAsScript.onload = saveToFile;
     document.getElementsByTagName('head')[0].appendChild(saveAsScript);


### PR DESCRIPTION
It change paths and also seems broke compatibility with
ability to save stuff from Chrome Console, since they moved to package
require system.